### PR TITLE
Edit Babel Configuration 

### DIFF
--- a/client/config-overrides.js
+++ b/client/config-overrides.js
@@ -1,0 +1,9 @@
+const { override, fixBabelImports } = require('customize-cra');
+
+ module.exports = override(
+   fixBabelImports('import', {
+     libraryName: 'antd',
+     libraryDirectory: 'es',
+     style: 'css',
+   }),
+ );

--- a/client/config-overrides.js
+++ b/client/config-overrides.js
@@ -7,4 +7,3 @@ const { override, fixBabelImports } = require('customize-cra');
      style: 'css',
    }),
  );
- 

--- a/client/config-overrides.js
+++ b/client/config-overrides.js
@@ -7,3 +7,4 @@ const { override, fixBabelImports } = require('customize-cra');
      style: 'css',
    }),
  );
+ 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2168,6 +2168,15 @@
         "object.assign": "^4.1.0"
       }
     },
+    "babel-plugin-import": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-import/-/babel-plugin-import-1.12.0.tgz",
+      "integrity": "sha512-3Fo7sJ2Hm71y1VJS7eMA/E7J5+roKJmzwia5BxzUQREBs6CRylwtvQq8m39W8nplG4Y7rZwOCndh5MzRTSmHpA==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/runtime": "^7.0.0"
+      }
+    },
     "babel-plugin-istanbul": {
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.4.tgz",
@@ -4082,6 +4091,14 @@
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.4.tgz",
       "integrity": "sha512-lAJUJP3M6HxFXbqtGRc0iZrdyeN+WzOWeY0q/VnFzI+kqVrYIzC7bWlKqCW7oCIdzoPkvfp82EVvrTlQ8zsWQg=="
+    },
+    "customize-cra": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/customize-cra/-/customize-cra-0.2.13.tgz",
+      "integrity": "sha512-Ot1HAM0ee7IDQBP222vJ8fDslshDGTtYFF4IGeLSd6QTL+3A7ZRy9KRbbwLsL+/zPKzQZ0Femlykn5Qjb18jMw==",
+      "requires": {
+        "lodash.flow": "^3.5.0"
+      }
     },
     "cyclist": {
       "version": "0.2.2",
@@ -6992,8 +7009,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -7030,8 +7046,7 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -7040,8 +7055,7 @@
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -7144,8 +7158,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -7155,7 +7168,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -7181,7 +7193,6 @@
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -7198,7 +7209,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -7271,8 +7281,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -7282,7 +7291,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -7358,8 +7366,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -7389,7 +7396,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -7407,7 +7413,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -7446,13 +7451,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         }
@@ -8121,6 +8124,11 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+    },
+    "lodash.flow": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
+      "integrity": "sha1-h79AKSuM+D5OjOGjrkIJ4gBxZ1o="
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -10949,6 +10957,23 @@
         "raf": "3.4.1",
         "regenerator-runtime": "0.13.2",
         "whatwg-fetch": "3.0.0"
+      }
+    },
+    "react-app-rewired": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/react-app-rewired/-/react-app-rewired-2.1.3.tgz",
+      "integrity": "sha512-NXC2EsQrnEMV7xD70rHcBq0B4PSEzjY/K2m/e+GRgit2jZO/uZApnpCZSKvIX2leLRN69Sqf2id0VXZ1F62CDw==",
+      "requires": {
+        "cross-spawn": "^6.0.5",
+        "dotenv": "^6.2.0",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+        }
       }
     },
     "react-dev-utils": {

--- a/client/package.json
+++ b/client/package.json
@@ -5,9 +5,12 @@
   "dependencies": {
     "antd": "^3.19.1",
     "axios": "^0.18.0",
+    "babel-plugin-import": "^1.12.0",
+    "customize-cra": "^0.2.13",
     "formik": "^1.5.7",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
+    "react-app-rewired": "^2.1.3",
     "react-dom": "^16.8.6",
     "react-router-dom": "^5.0.0",
     "react-scripts": "3.0.1",
@@ -16,9 +19,9 @@
     "yup": "^0.27.0"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
+    "start": "react-app-rewired start",
+    "build": "react-app-rewired build",
+    "test": "react-app-rewired test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/client/src/components/app/App.js
+++ b/client/src/components/app/App.js
@@ -1,10 +1,10 @@
 import React from "react";
-import "antd/dist/antd.css";
 
 import "./App.css";
 
 function App() {
-  return <></>;
+  return <>
+  </>;
 }
 
 export default App;


### PR DESCRIPTION
here i'm trying to get rid of entire style of antd and get the required ones. 
i mean instead of increase the bundle size and load entire style of antd library i will bundle just what we need. 

### Effected Files : 
1 - package.json
2 - package-lock.json
3 - config-overrides.js
4 - app.js

#### Package.json 
i added these libraries (react-app-rewired, customize-cra, babel-plugin-import).
react-app-rewired and customize-cra are just to edit webpack config (bable configuration specifically ) without eject react app .

#### package-lock.json
just to secure the app from any breaking changes in any in coming versions .

#### config-overrides.js
here we add some configuration to webpack configuration file . (<a href="https://ant.design/docs/react/use-with-create-react-app"> configuration  details</a>).

#### App.js
just remove the entire style .

Relates #61 